### PR TITLE
fix: add security hardening flags to build process

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,12 @@
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
+# 安全编译参数
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
+
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 DEB_BUILD_ARCH ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH)


### PR DESCRIPTION
1. Added DEB_BUILD_MAINT_OPTIONS with hardening=+all for comprehensive
security
2. Included additional compiler flags (-Wall) for warnings
3. Added linker flags for security features like RELRO, immediate
binding, and noexecstack
4. These changes improve binary security by enabling modern protection
mechanisms

fix: 在构建过程中添加安全加固标志

1. 添加了包含 hardening=+all 的 DEB_BUILD_MAINT_OPTIONS 以实现全面的安
全性
2. 包含了额外的编译器标志 (-Wall) 用于警告
3. 添加了链接器标志以实现 RELRO、立即绑定和 noexecstack 等安全特性
4. 这些更改通过启用现代保护机制提高了二进制文件的安全性
